### PR TITLE
Change comma-dangle to always-multiline

### DIFF
--- a/config/eslint/base.eslintrc
+++ b/config/eslint/base.eslintrc
@@ -9,7 +9,7 @@
     "constructor-super": 2,
 
 		// http://eslint.org/docs/rules/comma-dangle
-    "comma-dangle": [2, "never"],
+    "comma-dangle": [2, "always-multiline"],
 
 		// http://eslint.org/docs/rules/no-cond-assign
     "no-cond-assign": [2, "always"],

--- a/generators/app/templates/.eslintrc.json5
+++ b/generators/app/templates/.eslintrc.json5
@@ -9,7 +9,7 @@
     "constructor-super": 2,
 
     // http://eslint.org/docs/rules/comma-dangle
-    "comma-dangle": [2, "never"],
+    "comma-dangle": [2, "always-multiline"],
 
     // http://eslint.org/docs/rules/no-cond-assign
     "no-cond-assign": [2, "always"],


### PR DESCRIPTION
When cutting/pasting elements in an object/array, you never have to
worry about adding or removing a trailing comma. Could also switch to
`always`, even for single line, but this issue doesn't come up as much
with single line arrays/objects.

http://eslint.org/docs/rules/comma-dangle.html
