### PR TITLE
Turn off no-extra-parens for React

### DIFF
--- a/generators/react/templates/.eslintrc.json5
+++ b/generators/react/templates/.eslintrc.json5
@@ -1,4 +1,7 @@
 {
+  // JSX style mandates that we wrap our multiline elements in parens
+  "no-extra-parens": 0,
+
   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/
   "react/display-name": 0,
   "react/jsx-boolean-value": 2,


### PR DESCRIPTION
It's idiomatic react style to do this:

```
return (
  <div>
    <h1>My Component</h1>
    <p>Lorem ipsum... </p>
  </div>
);
```

Instead of this:

```
return <div>
    <h1>My Component</h1>
    <p>Lorem ipsum... </p>
  </div>;
```
